### PR TITLE
patch 2

### DIFF
--- a/stubdoc/cli.py
+++ b/stubdoc/cli.py
@@ -6,6 +6,7 @@ import argparse
 from argparse import ArgumentParser
 from argparse import Namespace
 import os
+import importlib
 
 from stubdoc import stubdoc
 
@@ -121,7 +122,7 @@ def _validate_module_path_arg(module_path_arg: Optional[str]) -> None:
     if not os.path.isfile(module_path_arg):
         raise ValueError(
             f'Specified module not found: {module_path_arg}')
-    if not os.path.splitext(module_path_arg)[1] in ['.py', '.pyd']:
+    if not any(module_path_arg.endswith(ending) for ending in importlib.machinery.all_suffixes()):
         raise ValueError(
             f'A non-python module path specified: {module_path_arg}')
 

--- a/stubdoc/stubdoc.py
+++ b/stubdoc/stubdoc.py
@@ -406,7 +406,11 @@ def _read_module(module_path: str) -> ModuleType:
     file_name: str = os.path.basename(module_path)
     dir_path: str = module_path.replace(file_name, '', 1)
     sys.path.append(dir_path)
-    package_name: str = os.path.splitext(module_path)[0]
+    package_name: str = None
+    for ending in importlib.machinery.all_suffixes():
+        if module_path.endswith(ending):
+            package_name = module_path[:-len(ending)]
+            break
     package_name = package_name.replace('/', '.')
     package_name = package_name.replace('\\', '.')
     while package_name.startswith('.'):

--- a/stubdoc/stubdoc.py
+++ b/stubdoc/stubdoc.py
@@ -406,7 +406,7 @@ def _read_module(module_path: str) -> ModuleType:
     file_name: str = os.path.basename(module_path)
     dir_path: str = module_path.replace(file_name, '', 1)
     sys.path.append(dir_path)
-    package_name: str = module_path.replace('.py', '')
+    package_name: str = os.path.splitext(module_path)[0]
     package_name = package_name.replace('/', '.')
     package_name = package_name.replace('\\', '.')
     while package_name.startswith('.'):


### PR DESCRIPTION
This patch enables handling of additional handling of .pyc, .pyw, and .{platform_suffix}.pyd.


[importlib.machinery.all_suffixes()](https://docs.python.org/3/library/importlib.html#importlib.machinery.all_suffixes) (introduced in 3.3) provides a list of extensions:

```
>>> importlib.machinery.all_suffixes()  
['.py', '.pyw', '.pyc', '.cp38-win_amd64.pyd', '.pyd']
```

I manually tested the handling of ".pyw", ".pyc" (moved and renamed from `__pycache__` folder), and ".cp38-win_amd64.pyd".


After cythonizing a module filename would be something like "mypackage\\mymodule.cp38-win_amd64.pyd".
mypy stubgen can usually handle module names and filenames. But for .pyd files with platform suffix only module names are accepted:
```stubgen --module mypackage.mymodule -o .```
So corresponding stubdoc call would be;
```stubdoc --module mypackage\\mymodule.cp38-win_amd64.pyd -s mypackage\\mymodule.pyi```